### PR TITLE
Fix BuilderComponent class inherit wrong base class

### DIFF
--- a/Packages/UGF.Builder/Runtime/BuilderComponent.cs
+++ b/Packages/UGF.Builder/Runtime/BuilderComponent.cs
@@ -1,6 +1,6 @@
 ﻿namespace UGF.Builder.Runtime
 {
-    public abstract class BuilderComponent<TResult> : BuilderBase, IBuilder<TResult>
+    public abstract class BuilderComponent<TResult> : BuilderComponentBase, IBuilder<TResult>
     {
         public T Build<T>() where T : TResult
         {

--- a/Packages/UGF.Builder/package.json
+++ b/Packages/UGF.Builder/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.builder",
   "displayName": "UGF.Builder",
   "version": "2.0.0",
-  "unity": "2020.2",
+  "unity": "2020.3",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Build pattern implementation.",
   "author": {
@@ -16,10 +16,7 @@
   "changelogUrl": "https://github.com/unity-game-framework/ugf-builder/blob/master/changelog.md",
   "licensesUrl": "https://github.com/unity-game-framework/ugf-builder/blob/master/license",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/@unity-game-framework"
-  },
-  "bintray": {
-    "registry": "https://api.bintray.com/content/unity-game-framework/public"
+    "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {}
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.3",
-    "com.unity.test-framework": "1.1.19"
+    "com.unity.ide.rider": "3.0.7",
+    "com.unity.test-framework": "1.1.24"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -7,27 +7,27 @@
       "dependencies": {}
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.3",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.1"
+        "com.unity.ext.nunit": "1.0.6"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.19",
+      "version": "1.1.24",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.5",
+        "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b12
-m_EditorVersionWithRevision: 2020.2.0b12 (92852ae685d8)
+m_EditorVersion: 2020.3.0f1
+m_EditorVersionWithRevision: 2020.3.0f1 (c7b5465681fb)


### PR DESCRIPTION
- Update Unity project to `2020.3` version.
- Update project workflows.
- Fix `BuilderComponent<TResult>` base class to `BuilderComponentBase`.